### PR TITLE
Treat all 2XX HTTP response codes as successful.

### DIFF
--- a/pyoanda/client.py
+++ b/pyoanda/client.py
@@ -67,7 +67,7 @@ class Client(object):
         try:
             resp = getattr(self.session, method)(**kwargs)
             rjson = resp.json()
-            assert resp.status_code == 200
+            assert resp.ok
         except AssertionError:
             msg = "OCode-{}: {}".format(resp.status_code, rjson["message"])
             raise BadRequest(msg)
@@ -95,7 +95,7 @@ class Client(object):
             kwargs["data"] = params
         try:
             resp = getattr(self.session, method)(**kwargs)
-            assert resp.status_code == 200
+            assert resp.ok
         except AssertionError:
             raise BadRequest(resp.status_code)
         except Exception as e:

--- a/pyoanda/tests/test_client.py
+++ b/pyoanda/tests/test_client.py
@@ -44,7 +44,7 @@ class TestClientFundation(unittest.TestCase):
             c.session = requests.Session()
         obj = mock
         setattr(obj, "json", lambda: 1)
-        setattr(obj, "status_code", 200)
+        setattr(obj, "ok", True)
         with mock.patch.object(c.session, 'get', return_value=obj):
             c._Client__call(uri="test", params={"test": "test"}, method="get")
 
@@ -62,6 +62,7 @@ class TestClientFundation(unittest.TestCase):
         obj = mock
         setattr(obj, "json", lambda: {"message": "Bad request"})
         setattr(obj, "status_code", 400)
+        setattr(obj, "ok", False)
         with mock.patch.object(c.session, 'get', return_value=obj):
             with self.assertRaises(BadRequest):
                 c._Client__call(uri="test", params=None, method="get")
@@ -76,7 +77,7 @@ class TestClientFundation(unittest.TestCase):
             c.session = requests.Session()
         obj = mock
         setattr(obj, "json", lambda: 1)
-        setattr(obj, "status_code", 200)
+        setattr(obj, "ok", True)
         with mock.patch.object(c.session, 'get', return_value=obj):
             c._Client__call_stream(
                 uri="test",
@@ -102,6 +103,7 @@ class TestClientFundation(unittest.TestCase):
         obj = mock
         setattr(obj, "json", lambda: {"message": "Bad request"})
         setattr(obj, "status_code", 400)
+        setattr(obj, "ok", False)
         with mock.patch.object(c.session, 'get', return_value=obj):
             with self.assertRaises(BadRequest):
                 c._Client__call_stream(uri="test", params={"test": "test"}, method="get")


### PR DESCRIPTION
Generally HTTP response codes in the 200 - 299 range are "success" responses.  For some APIs the 300 - 399 range might also be considered successful.

This change treats the 2XX range as success statuses, but leaves the 3XX range as is.

The [oanda order documentation](http://developer.oanda.com/rest-live/orders/) indicates that 201 response codes may be used for the order create method (click "see more" to see details; the first one that they show returns 200, but the rest show 201s - this may be a bug in their documentation or it may be that the method sometimes returns 200, sometimes returns 201).