### PR TITLE
Implement support for account creation and retrieval.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ python setup.py test
 ### Code example
 
 ```python
-    from pyoanda import Client, SANDBOX
+    from pyoanda import Client, PRACTICE
 
     c = Client(
-        environment=SANDBOX,
+        environment=PRACTICE,
         account_id="Your Oanda account ID",
         access_token="Your Oanda access token"
     )
@@ -43,6 +43,25 @@ python setup.py test
         granularity="S30"
     )
 ```
+
+Note that if you are indenting to use the sandbox environment, you should first use the  API to create an account then use the account_id to run the example above.
+
+```python
+    from pyoanda import Client, SANDBOX
+
+    c = Client(
+        environment=SANDBOX,
+        account_id=None,
+        access_token=None
+    )
+
+    # Create an account
+    user = c.create_account()
+
+    # Retrieve the username and accountId values for future use
+    print "username: %s\naccount_id: %d" % (user['username'], user['accountId'])
+```
+
 
 ### Run test
 ```shell

--- a/pyoanda/client.py
+++ b/pyoanda/client.py
@@ -20,7 +20,7 @@ class Client(object):
         self.domain, self.domain_stream = environment
         self.access_token = access_token
         self.account_id = account_id
-        if not self.get_credentials():
+        if account_id and not self.get_credentials():
             raise BadCredentials()
 
     def get_credentials(self):
@@ -44,9 +44,10 @@ class Client(object):
     def __session_stablisher(self):
         if not hasattr(self, "session") or not self.session:
             self.session = requests.Session()
-            self.session.headers.update(
-                {'Authorization': 'Bearer {}'.format(self.access_token)}
-            )
+            if self.access_token:
+                self.session.headers.update(
+                    {'Authorization': 'Bearer {}'.format(self.access_token)}
+                )
 
     def __call(self, uri, params=None, method="get"):
         """Only returns the response, nor the status_code
@@ -353,3 +354,54 @@ class Client(object):
             http://developer.oanda.com/rest-live/transaction-history/#transactionTypes
         """
         raise NotImplementedError()
+
+    def create_account(self, currency=None):
+        """ Create a new account.
+        
+            This call is only available on the sandbox system. Please
+            create accounts on fxtrade.oanda.com on our production
+            system.
+
+            See more:
+            http://developer.oanda.com/rest-sandbox/accounts/#-a-name-createtestaccount-a-create-a-test-account
+        """
+        url = "{0}/{1}/accounts".format(
+            self.domain,
+            self.API_VERSION
+        )
+        params = {
+            "currency": currency
+        }
+        try:
+            return self._Client__call(uri=url, params=params, method="post")
+        except RequestException:
+            return False
+        except AssertionError:
+            return False
+
+    def get_accounts(self, username=None):
+        """ Get a list of accounts owned by the user.
+
+            Parameters
+            ----------
+            username : string
+                The name of the user. Note: This is only required on the
+                sandbox, on production systems your access token will
+                identify you.
+
+            See more:
+            http://developer.oanda.com/rest-sandbox/accounts/#-a-name-getaccountsforuser-a-get-accounts-for-a-user
+        """
+        url = "{0}/{1}/accounts".format(
+            self.domain,
+            self.API_VERSION
+        )
+        params = {
+            "username": username
+        }
+        try:
+            return self._Client__call(uri=url, params=params, method="get")
+        except RequestException:
+            return False
+        except AssertionError:
+            return False

--- a/pyoanda/tests/test_client.py
+++ b/pyoanda/tests/test_client.py
@@ -186,3 +186,32 @@ class TestOrdersAPI(unittest.TestCase):
 
     def test_close_order(self):
         pass
+
+
+class TestAccountAPI(unittest.TestCase):
+    def setUp(self):
+        with mock.patch.object(Client, 'get_credentials', return_value=True):
+            self.client = Client(
+                ("http://mydomain.com", "http://mystreamingdomain.com"),
+                "my_account",
+                "my_token"
+            )
+
+    def test_create_account(self):
+        with mock.patch.object(Client, '_Client__call', return_value=True):
+            assert self.client.create_account()
+
+    def test_create_account_with_currency(self):
+        with mock.patch.object(Client, '_Client__call', return_value=True):
+            assert self.client.create_account('AUD')
+            assert self.client.create_account(currency='AUD')
+
+    def test_get_accounts(self):
+        with mock.patch.object(Client, '_Client__call', return_value=True):
+            assert self.client.get_accounts()
+
+    def test_get_accounts_with_username(self):
+        with mock.patch.object(Client, '_Client__call', return_value=True):
+            assert self.client.get_accounts('bob')
+            assert self.client.get_accounts(username='bob')
+


### PR DESCRIPTION
The Oanda sandbox environment doesn't support users' normal account ID,
so in order to work in the sandbox we need to support the account
creation API.

This change adds create_account (only useful in the sandbox) and
get_accounts (useful in all environments).

This can be used to work in the sandbox as follows.

```python
from pyoanda import Client, SANDBOX

# Create a client without credentials
c = Client(SANDBOX, None, None)

# Create a new account, which gives you a user ID; may want to save this
# for future runs!
user = c.create_account()

# Set the account ID for the client, as many methods require it
c.account_id = user['accountId']

# Now you're good to go with other methods, e.g.
orders = c.get_orders()
```