### PR TITLE
Support retrieving full transaction history.

### DIFF
--- a/pyoanda/tests/test_client.py
+++ b/pyoanda/tests/test_client.py
@@ -13,6 +13,8 @@ from requests.exceptions import RequestException
 import requests_mock
 import json
 from decimal import Decimal
+from zipfile import ZipFile
+from io import BytesIO
 
 from ..client import Client
 from ..order import Order
@@ -317,3 +319,90 @@ class TestTransactionAPI(unittest.TestCase):
         location = 'http://example.com/transactions.json.gz'
         m.get(requests_mock.ANY, headers={'Location': location}, status_code=202)
         self.assertEqual(location, self.client.request_transaction_history())
+
+    @requests_mock.Mocker()
+    def test_get_transaction_history(self, m):
+        # Mock zip file content
+        content = BytesIO()
+        with ZipFile(content, 'w') as zip:
+            zip.writestr('transactions.json', json.dumps({'ok': True}))
+        content.seek(0)
+
+        # Mock requests, one HEAD to check if it's there, one GET once it is
+        location = 'http://example.com/transactions.json.gz'
+        m.head(location, status_code=200)
+        m.get(location, body=content, status_code=200)
+
+        method = 'request_transaction_history'
+        with mock.patch.object(Client, method, return_value=location):
+            transactions = self.client.get_transaction_history()
+            assert transactions['ok']
+            assert m.call_count == 2
+
+    @requests_mock.Mocker()
+    def test_get_transaction_history_slow(self, m):
+        """Ensures that get_transaction_history retries requests."""
+        # Mock zip file content
+        content = BytesIO()
+        with ZipFile(content, 'w') as zip:
+            zip.writestr('transactions.json', json.dumps({'ok': True}))
+        content.seek(0)
+
+        # Mock requests, one HEAD to check if it's there, one GET once it is
+        location = 'http://example.com/transactions.json.gz'
+        m.head(location, [{'status_code': 404}, {'status_code': 200}])
+        m.get(location, body=content, status_code=200)
+
+        method = 'request_transaction_history'
+        with mock.patch.object(Client, method, return_value=location):
+            transactions = self.client.get_transaction_history()
+            assert transactions['ok']
+            assert m.call_count == 3
+
+    @requests_mock.Mocker()
+    def test_get_transaction_history_gives_up(self, m):
+        """Ensures that get_transaction_history eventually gives up."""
+        # Mock requests, one HEAD to check if it's there, one GET once it is
+        location = 'http://example.com/transactions.json.gz'
+        m.head(location, [{'status_code': 404}, {'status_code': 404}])
+
+        method = 'request_transaction_history'
+        with mock.patch.object(Client, method, return_value=location):
+            transactions = self.client.get_transaction_history(.3)
+            assert not transactions
+            # Possible timing issue, may be one or the other
+            assert m.call_count == 2 or m.call_count == 3
+
+    @requests_mock.Mocker()
+    def test_get_transaction_history_handles_bad_files(self, m):
+        """Ensures that get_transaction_history gracefully handles bad files.
+        """
+        # Mock requests, one HEAD to check if it's there, one GET once it is
+        location = 'http://example.com/transactions.json.gz'
+        m.head(location, status_code=200)
+        m.get(location, text='invalid', status_code=200)
+
+        method = 'request_transaction_history'
+        with mock.patch.object(Client, method, return_value=location):
+            transactions = self.client.get_transaction_history()
+            assert not transactions
+
+    @requests_mock.Mocker()
+    def test_get_transaction_history_slow(self, m):
+        """Ensures that get_transaction_history handles empty files."""
+        # Mock zip file content
+        content = BytesIO()
+        with ZipFile(content, 'w') as zip:
+            pass
+        content.seek(0)
+
+        # Mock requests, one HEAD to check if it's there, one GET once it is
+        location = 'http://example.com/transactions.json.gz'
+        m.head(location, [{'status_code': 404}, {'status_code': 200}])
+        m.get(location, body=content, status_code=200)
+
+        method = 'request_transaction_history'
+        with mock.patch.object(Client, method, return_value=location):
+            transactions = self.client.get_transaction_history()
+            assert not transactions
+


### PR DESCRIPTION
When requesting full transaction history, the Oanda API only provides a
url to the location that the history will eventually be available at.
This provides a method for polling the location until it's available,
then downloading the file, processing the content of the ZIP and
extracting the result.

Note that this cannot be tested in the sandbox, as it doesn't return a
valid URL for the transaction history.